### PR TITLE
Add Keep Alive option to General Config Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Settings relating to the integration itself.
 | Option                   | Description                                                                                                                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | API Timeout              | The maximum amount of time to wait for a response from the API in seconds                                                                                                                                           |
-| Keep Alive               | The amount of time in minutes the model should stay loaded in memory after a request (-1 stay loaded indefinitely, 0 unload immediately after request)                                                              |
+| Keep Alive               | The amount of time in seconds the model should stay loaded in memory after a request (-1 stay loaded indefinitely, 0 unload immediately after request)                                                              |
 
 #### System Prompt
 The starting text for the AI language model to generate new text from. This text can include information about your Home Assistant instance, devices, and areas and is written using Home Assistant Templating.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Settings relating to the integration itself.
 | Option                   | Description                                                                                                                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | API Timeout              | The maximum amount of time to wait for a response from the API in seconds                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep Alive               | The amount of time in minutes the model should stay loaded in memory after a request (-1 stay loaded indefinitely, 0 unload immediately after request)                                                              |
 
 #### System Prompt
 The starting text for the AI language model to generate new text from. This text can include information about your Home Assistant instance, devices, and areas and is written using Home Assistant Templating.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Settings relating to the integration itself.
 | Option                   | Description                                                                                                                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | API Timeout              | The maximum amount of time to wait for a response from the API in seconds                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Keep Alive               | The amount of time in minutes the model should stay loaded in memory after a request (-1 stay loaded indefinitely, 0 unload immediately after request)                                                              |
 
 #### System Prompt

--- a/custom_components/ollama_conversation/__init__.py
+++ b/custom_components/ollama_conversation/__init__.py
@@ -22,6 +22,7 @@ from .const import (
 
     CONF_BASE_URL,
     CONF_TIMEOUT,
+    CONF_KEEP_ALIVE,
     CONF_MODEL,
     CONF_CTX_SIZE,
     CONF_MAX_TOKENS,
@@ -35,6 +36,7 @@ from .const import (
     CONF_PROMPT_SYSTEM,
 
     DEFAULT_TIMEOUT,
+    DEFAULT_KEEP_ALIVE,
     DEFAULT_MODEL,
     DEFAULT_CTX_SIZE,
     DEFAULT_MAX_TOKENS,
@@ -204,6 +206,7 @@ class OllamaAgent(conversation.AbstractConversationAgent):
             "context": messages["context"],
             "system": messages["system"],
             "prompt": messages["prompt"],
+            "keep_alive": self.entry.options.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE),
             "stream": False,
             "options": {
                 "mirostat": int(self.entry.options.get(CONF_MIROSTAT_MODE, DEFAULT_MIROSTAT_MODE)),

--- a/custom_components/ollama_conversation/__init__.py
+++ b/custom_components/ollama_conversation/__init__.py
@@ -198,6 +198,7 @@ class OllamaAgent(conversation.AbstractConversationAgent):
     ):
         """Process a sentence."""
         model = self.entry.options.get(CONF_MODEL, DEFAULT_MODEL)
+        keep_alive = self.entry.options.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE)
 
         LOGGER.debug("Prompt for %s: %s", model, messages["prompt"])
 
@@ -206,7 +207,7 @@ class OllamaAgent(conversation.AbstractConversationAgent):
             "context": messages["context"],
             "system": messages["system"],
             "prompt": messages["prompt"],
-            "keep_alive": self.entry.options.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE),
+            "keep_alive": keep_alive,
             "stream": False,
             "options": {
                 "mirostat": int(self.entry.options.get(CONF_MIROSTAT_MODE, DEFAULT_MIROSTAT_MODE)),

--- a/custom_components/ollama_conversation/config_flow.py
+++ b/custom_components/ollama_conversation/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
 
     CONF_BASE_URL,
     CONF_TIMEOUT,
+    CONF_KEEP_ALIVE,
     CONF_MODEL,
     CONF_CTX_SIZE,
     CONF_MAX_TOKENS,
@@ -41,6 +42,7 @@ from .const import (
 
     DEFAULT_BASE_URL,
     DEFAULT_TIMEOUT,
+    DEFAULT_KEEP_ALIVE,
     DEFAULT_MODEL,
     DEFAULT_CTX_SIZE,
     DEFAULT_MAX_TOKENS,
@@ -71,6 +73,7 @@ DEFAULT_OPTIONS = types.MappingProxyType(
     {
         CONF_BASE_URL: DEFAULT_BASE_URL,
         CONF_TIMEOUT: DEFAULT_TIMEOUT,
+        CONF_KEEP_ALIVE: DEFAULT_KEEP_ALIVE,
         CONF_MODEL: DEFAULT_MODEL,
         CONF_CTX_SIZE: DEFAULT_CTX_SIZE,
         CONF_MAX_TOKENS: DEFAULT_MAX_TOKENS,
@@ -222,6 +225,11 @@ def ollama_schema_general_config(options: MappingProxyType[str, Any]) -> dict:
             CONF_TIMEOUT,
             description={"suggested_value": options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)},
             default=DEFAULT_TIMEOUT,
+        ): int,
+        vol.Optional(
+            CONF_KEEP_ALIVE,
+            description={"suggested_value": options.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE)},
+            default=DEFAULT_KEEP_ALIVE,
         ): int,
     }
 

--- a/custom_components/ollama_conversation/const.py
+++ b/custom_components/ollama_conversation/const.py
@@ -10,6 +10,7 @@ MENU_OPTIONS = ["general_config", "model_config", "prompt_system"]
 
 CONF_BASE_URL = "base_url"
 CONF_TIMEOUT = "timeout"
+CONF_KEEP_ALIVE = "keep_alive"
 CONF_MODEL = "chat_model"
 CONF_CTX_SIZE = "ctx_size"
 CONF_MAX_TOKENS = "max_tokens"
@@ -24,6 +25,7 @@ CONF_PROMPT_SYSTEM = "prompt"
 
 DEFAULT_BASE_URL = "http://homeassistant.local:11434"
 DEFAULT_TIMEOUT = 60
+DEFAULT_KEEP_ALIVE = 0
 DEFAULT_MODEL = "llama2:latest"
 DEFAULT_CTX_SIZE = 2048
 DEFAULT_MAX_TOKENS = 128

--- a/custom_components/ollama_conversation/strings.json
+++ b/custom_components/ollama_conversation/strings.json
@@ -30,7 +30,8 @@
             "general_config": {
                 "title": "General Settings",
                 "data": {
-                    "timeout": "API Timeout"
+                    "timeout": "API Timeout",
+                    "keep_alive": "Keep Alive"
                 }
             },
             "model_config": {

--- a/custom_components/ollama_conversation/translations/en.json
+++ b/custom_components/ollama_conversation/translations/en.json
@@ -30,7 +30,8 @@
             "general_config": {
                 "title": "General Settings",
                 "data": {
-                    "timeout": "API Timeout"
+                    "timeout": "API Timeout",
+                    "keep_alive": "Keep Alive"
                 }
             },
             "model_config": {


### PR DESCRIPTION
Firstly apologies if I've done any of this wrong, this is my first ever PR!
I've added an option to the 'General Settings' config flow for Keep Alive. This should send the configured keep_alive parameter with the chat generation request. I've tested on my setup and everything seems to be working. This should close issue #36 
I hope I've done everything right, thanks for all the work on this integration!